### PR TITLE
Updated Invalid main field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "multi-hashing",
     "version": "1.0.0",
-    "main": "multihashing",
+    "main": "index.js",
     "author": {
         "name": "Matthew Little",
         "email": "zone117x@gmail.com"


### PR DESCRIPTION
Fixed following warning everytime I run the code.  
```
(node:6644) [DEP0128] DeprecationWarning: Invalid 'main' field in 'E:\Desktop\Nodejs\crypto-algos\node_modules\multi-hashing\package.json' of 'multihashing'. Please either fix that or report it to the module author
(Use `node --trace-deprecation ...` to show where the warning was created)
```